### PR TITLE
Fix build for sys-devel/reflex

### DIFF
--- a/src/calc.lex
+++ b/src/calc.lex
@@ -11,6 +11,7 @@
 %{
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "formula-parser.h"
 #include "y.tab.h"


### PR DESCRIPTION
When LEX=reflex is used, this compiling calc.lex fails with a implicit function declaration when
Werror=implicit-function-declaration. (Like with clang16)

Bug: https://bugs.gentoo.org/884361